### PR TITLE
Update google/protobuf dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require": {
     "php": ">=5.6",
-    "google/protobuf": "v3.6.1.3",
+    "google/protobuf": "^3.15.0",
     "mdurrant/php-binary-reader": "^1.0",
     "ext-zlib": "*"
   },


### PR DESCRIPTION
Versions below 3.15 do have security issues:
https://github.com/advisories/GHSA-77rm-9x9h-xj3g